### PR TITLE
Adding Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .settings
 .classpath
 .mvn/
+.factorypath
 
 mvnw*
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,19 @@ A RESTful API for evaluating output of NLP systems.
 
     `java -jar target/nlp-eval-service-0.1.0.jar`
 
+## Kubernetes installation via Helm
+The included Helm chart (see `chart/`) can be used to install the NLP evaluation service in a Kubernetes cluster using [Helm](https://helm.sh/). It is current configured to as a load balancer service that can take a static IP as an input argument. Create a static IP (for GCP it must be a regional IP), and install using the following:
+
+`helm install --set service.loadBalancerIP=<static-ip> nlp-eval-svc ./chart`
+
+The Web UI will be available at the static IP (no additional port necessary).
+
+Relatedly, the chart can be packaged by Maven with the command shown below. Once run, the packaged chart can be found in `target/helm/repo`.
+
+`mvn clean package helm:init helm:lint helm:dependency-build helm:package`
 
 ## Using the service via the Web UI
-In a web browser, visit `http://<host-name>:8080` where *<host-name>* is the IP address or name of the host where you have installed the NLP Evaluation Service. If the service is installed on your local machine, then *<host-name>* will be *localhost*, i.e. [http://localhost:8080](http://localhost:8080).
+In a web browser, visit `http://<host-name>:8080` where *<host-name>* is the IP address or name of the host where you have installed the NLP Evaluation Service. **NOTE, if you have installed the service on a Kubernetes cluster using the provided Helm chart, the service will be available at the static IP that you provided (no additional port necessary).** If the service is installed on your local machine, then *<host-name>* will be *localhost*, i.e. [http://localhost:8080](http://localhost:8080).
 
 1. Upload the test annotation files in the BioNLP format that are to be evaluated by selecting them using the *Choose Files* button. 
 
@@ -57,7 +67,7 @@ In a web browser, visit `http://<host-name>:8080` where *<host-name>* is the IP 
 
 ## Using the service via the command line
 
-From the command line, the `curl` command can be used to submit evaluation requests. The URL to target is `http://<host-name>:8080` where *<host-name>* is the IP address or name of the host where you have installed the NLP Evaluation Service. If the service is installed on your local machine, then *<host-name>* will be *localhost*, i.e. [http://localhost:8080](http://localhost:8080). 
+From the command line, the `curl` command can be used to submit evaluation requests. The URL to target is `http://<host-name>:8080` where *<host-name>* is the IP address or name of the host where you have installed the NLP Evaluation Service. If the service is installed on your local machine, then *<host-name>* will be *localhost*, i.e. [http://localhost:8080](http://localhost:8080). **NOTE, if you have installed the service on a Kubernetes cluster using the provided Helm chart, the service will be available at the static IP that you provided (no additional port necessary).**
 
 Each file is specified using `-F files=@"<file-name>"`, where *<file-name>* is the name of a file to be evaluated, e.g. 11319941.bionlp. Multiple `-F` blocks can be added to evaluate multiple files.
 

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: nlp-eval-svc
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.1.0

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "nlp-eval-svc.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "nlp-eval-svc.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "nlp-eval-svc.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nlp-eval-svc.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nlp-eval-svc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nlp-eval-svc.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nlp-eval-svc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "nlp-eval-svc.labels" -}}
+helm.sh/chart: {{ include "nlp-eval-svc.chart" . }}
+{{ include "nlp-eval-svc.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nlp-eval-svc.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nlp-eval-svc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nlp-eval-svc.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "nlp-eval-svc.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nlp-eval-svc.fullname" . }}
+  labels:
+    {{- include "nlp-eval-svc.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nlp-eval-svc.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nlp-eval-svc.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "nlp-eval-svc.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "nlp-eval-svc.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "nlp-eval-svc.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nlp-eval-svc.fullname" . }}
+  labels:
+    {{- include "nlp-eval-svc.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "nlp-eval-svc.selectorLabels" . | nindent 4 }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nlp-eval-svc.serviceAccountName" . }}
+  labels:
+    {{- include "nlp-eval-svc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/chart/templates/tests/test-connection.yaml
+++ b/chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "nlp-eval-svc.fullname" . }}-test-connection"
+  labels:
+    {{- include "nlp-eval-svc.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "nlp-eval-svc.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,73 @@
+# Default values for nlp-eval-svc.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: registry.gitlab.com/william-baumgartner/translator-nlp-eval-service
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: LoadBalancer
+  port: 80
+  loadBalancerIP: 
+
+ingress:
+  enabled: false
+  annotations: {
+    kubernetes.io/ingress.global-static-ip-name: nlp-eval-svc-idpaddress,
+    networking.gke.io/managed-certificates: nlp-eval-svc-certificate
+  }
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+    # - secretName: nlp-eval-svc-certificate
+    #   hosts:
+    #      - chart-example.local
+  
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 	</properties>
-
+	
 	<dependencies>
 		<dependency>
 			<groupId>javax.jms</groupId>
@@ -56,6 +56,11 @@
 			<version>3.5.2</version>
 		</dependency>
 
+		<dependency>
+			<groupId>com.kiwigrid</groupId>
+			<artifactId>helm-maven-plugin</artifactId>
+			<version>5.1</version>
+		</dependency>
 	</dependencies>
 
 	<repositories>
@@ -70,6 +75,19 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>com.kiwigrid</groupId>
+				<artifactId>helm-maven-plugin</artifactId>
+				<version>5.3</version>
+				<!-- <extensions>true</extensions> -->
+				<configuration>
+					<chartDirectory>${project.basedir}</chartDirectory>
+					<chartVersion>${project.version}</chartVersion>
+					<!-- This is the related section to use local binary with auto-detection 
+						enabled. -->
+					<useLocalHelmBinary>true</useLocalHelmBinary>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Adding a Helm chart to facilitate K8s deployment of the NLP evaluation
service. The pom has also been supplemented with a helm-maven-plugin to
facilitate packaging of the Helm chart for distribution to a chart
repository. The chart permits user specification of a static IP address
for the service. Implementation of the K8s service as a load balancer
requires the static IP to be ‘regional’ (at least on GCP). Resolves #3.